### PR TITLE
Use ID's for chapter redirecting

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -180,10 +180,7 @@ export default class DigiBook extends H5P.EventDispatcher {
       this.instances[this.activeChapter].childInstances.map(x => {
         x.trigger('resize');
       });
-
-      setTimeout(() => {
-        this.trigger('resize');
-      }, 1000);
+      this.trigger('resize');
     };
 
     /**

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -196,19 +196,6 @@ export default class DigiBook extends H5P.EventDispatcher {
       this.newHandler.redirectFromComponent = false;
     };
 
-    /**
-     * Allow for external redirects via hash parameters
-     * @param {int} h5pbookid identifier of which book in question
-     * @param {int} chapter Chapter which should be redirected to
-     * @param {int} section Which section in the abovementioned chapter
-     * @example exampleurl/#h5pbookid=X&chapter=Y&section=Z
-     */
-    document.addEventListener('readystatechange', event => {
-      if (event.target.readyState === "complete") {
-        this.newHandler = this.retrieveHashFromUrl();
-        this.changeChapter(true);
-      }
-    });
 
     /**
      * Triggers whenever the hash changes, indicating that a chapter redirect is happening
@@ -261,8 +248,6 @@ export default class DigiBook extends H5P.EventDispatcher {
 
             // Assert that the handler actually is from this content type. 
             if (tempHandler.h5pbookid == self.contentId && tempHandler.chapter) {
-              //Fix off by one-errors
-              tempHandler.chapter = parseInt(tempHandler.chapter) - 1;
               self.newHandler = tempHandler;
             }
           }

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -44,16 +44,8 @@ export default class DigiBook extends H5P.EventDispatcher {
       });
 
       if (redirObj.h5pbookid == self.contentId && redirObj.chapter) {
-        //Parameter sanitization
-        if (isNaN(redirObj.chapter && parseInt(redirObj.chapter) > 0)) {
+        if (!redirObj.chapter) {
           return;
-        }
-        else {
-          // Fix off by one to support native arrays
-          redirObj.chapter = parseInt(redirObj.chapter) - 1;
-        }
-        if (isNaN(redirObj.section && redirObj.section > 0)) {
-          delete redirObj.section;
         }
       }
       return redirObj;
@@ -64,8 +56,8 @@ export default class DigiBook extends H5P.EventDispatcher {
      * 
      * Used for checking if the user attempts to redirect to the same section twice
      * @param {object} hashObj - the object that should be compared to the hash
-     * @param {number} hashObj.chapter
-     * @param {number} hashObj.section
+     * @param {String} hashObj.chapter
+     * @param {String} hashObj.section
      * @param {number} hashObj.h5pbookid
      */
     this.isCurrentHashSameAsRedirect = (hashObj) => {
@@ -105,7 +97,7 @@ export default class DigiBook extends H5P.EventDispatcher {
       this.newHandler.redirectFromComponent = true;
       // Create the new hash
       const idString = 'h5pbookid=' + this.newHandler.h5pbookid;
-      const chapterString = '&chapter=' + (this.newHandler.chapter + 1);
+      const chapterString = '&chapter=' + this.newHandler.chapter;
       let sectionString = "";
       if (this.newHandler.section !== undefined) {
         sectionString = '&section=' + this.newHandler.section;

--- a/src/scripts/pagecontent.js
+++ b/src/scripts/pagecontent.js
@@ -80,6 +80,7 @@ class PageContent extends H5P.EventDispatcher {
       const newInstance = H5P.newRunnable(config.chapters[i], contentId, H5P.jQuery(newColumn), contentData);
       newInstance.childInstances = newInstance.getInstances();
       newColumn.classList.add('h5p-digibook-chapter');
+      newColumn.id = newInstance.subContentId;
       newInstance.title = config.chapters[i].metadata.title;
       newInstance.completed = false;
       
@@ -142,6 +143,10 @@ class PageContent extends H5P.EventDispatcher {
     }
   }
 
+  findChapterIndex(id) {
+    return this.columnElements.findIndex(x => x.id === id);
+  }
+
   /**
    * Input in targetPage should be: 
    * @param {int} chapter - The given chapter that should be opened
@@ -154,12 +159,11 @@ class PageContent extends H5P.EventDispatcher {
 
     this.targetPage = newHandler;
     const oldChapterNum = this.parent.getActiveChapter();
-    const newChapterNum = parseInt(this.targetPage.chapter);
+    const newChapterNum = this.findChapterIndex(this.targetPage.chapter);
 
-
-    if (this.targetPage.chapter < this.columnElements.length) {
+    if (newChapterNum < this.columnElements.length) {
       const oldChapter = this.columnElements[oldChapterNum];
-      const targetChapter = this.columnElements[this.targetPage.chapter];
+      const targetChapter = this.columnElements[newChapterNum];
       
       if (oldChapterNum !== newChapterNum && !redirectOnLoad) {
         this.parent.animationInProgress = true;
@@ -169,7 +173,7 @@ class PageContent extends H5P.EventDispatcher {
         var newPageProgress = '';
         var oldPageProgrss = '';
         // The pages will progress from right to left
-        if (oldChapterNum < this.targetPage.chapter) {
+        if (oldChapterNum < newChapterNum) {
           newPageProgress = 'right';
           oldPageProgrss = 'left';
         }
@@ -199,7 +203,7 @@ class PageContent extends H5P.EventDispatcher {
         }
       }
 
-      this.parent.sideBar.redirectHandler(this.targetPage.chapter);
+      this.parent.sideBar.redirectHandler(newChapterNum);
       if (!redirectOnLoad) {
         this.parent.updateChapterProgress(oldChapterNum);
       }

--- a/src/scripts/pagecontent.js
+++ b/src/scripts/pagecontent.js
@@ -227,9 +227,9 @@ class PageContent extends H5P.EventDispatcher {
         inactiveElems.map(x => x.classList.add('h5p-content-hidden'));
 
         const activeElem = this.columnElements[activeChapter];
+        this.parent.resizeChildInstances();  
 
         activeElem.classList.remove('h5p-digibook-offset-right', 'h5p-digibook-offset-left', 'h5p-digibook-animate-new');
-        
         
         let footerStatus = this.parent.shouldFooterBeVisible(activeElem.clientHeight);
         this.parent.statusBar.editFooterVisibillity(footerStatus);
@@ -237,7 +237,6 @@ class PageContent extends H5P.EventDispatcher {
         //Focus on section only after the page scrolling is finished
         this.parent.animationInProgress = false;
         this.redirectSection(this.targetPage.section);
-        this.parent.resizeChildInstances();  
       }
     });
   }

--- a/src/scripts/sidebar.js
+++ b/src/scripts/sidebar.js
@@ -82,9 +82,11 @@ class SideBar extends H5P.EventDispatcher {
     for (let i = 0; i < input.length; i++) {
       const sections = this.findSectionsInChapter(input[i]);
       const chapterTitle = input[i].metadata.title;
+      const id = input[i].subContentId;
       chapters.push({
         sections,
-        title:chapterTitle
+        title:chapterTitle,
+        id
       });
     }
     return chapters;
@@ -189,12 +191,8 @@ class SideBar extends H5P.EventDispatcher {
 
     //Add classes
     titleDiv.classList.add('h5p-digibook-navigation-chapter-title');
-
     chapterDiv.classList.add('h5p-digibook-navigation-chapter');
-
-
     sectionsDiv.classList.add('h5p-digibook-navigation-sectionlist');
-
     
     title.innerHTML = chapter.title;
     title.setAttribute("title", chapter.title);
@@ -207,12 +205,9 @@ class SideBar extends H5P.EventDispatcher {
       circleIcon.classList.add('icon-chapter-blank', 'h5p-digibook-navigation-chapter-progress');
     }
 
-
-
     titleDiv.appendChild(arrowIcon);
     titleDiv.appendChild(title);
     titleDiv.appendChild(circleIcon);
-
     chapterDiv.appendChild(titleDiv);
 
     titleDiv.onclick = (event) => {
@@ -242,11 +237,10 @@ class SideBar extends H5P.EventDispatcher {
       singleSection.appendChild(a);
       
       sectionsDiv.appendChild(singleSection);
-      
       a.onclick = () => {
         that.parent.trigger('newChapter', {
           h5pbookid: that.parent.contentId,
-          chapter: chapterIndex,
+          chapter: this.chapters[chapterIndex].id,
           section: section.id
         });
       };

--- a/src/scripts/statusbar.js
+++ b/src/scripts/statusbar.js
@@ -87,18 +87,18 @@ class StatusBar extends H5P.EventDispatcher {
       if (event.data.toTop) {
         eventInput.section = "top";
       }
-      
+
       if (event.data.direction === 'next') {
         if (this.parent.activeChapter+1 < this.parent.instances.length) {
-          eventInput.chapter = (this.parent.activeChapter+1);
+          eventInput.chapter = this.parent.instances[this.parent.activeChapter+1].subContentId;
         }
       }
       else if (event.data.direction === 'prev') {
         if (this.parent.activeChapter > 0) {
-          eventInput.chapter = (this.parent.activeChapter-1);
+          eventInput.chapter = this.parent.instances[this.parent.activeChapter-1].subContentId;
         }
       }
-      if (isNaN(eventInput.chapter) === false) {
+      if (eventInput.chapter) {
         this.parent.trigger('newChapter', eventInput);
       }
     });

--- a/src/scripts/statusbar.js
+++ b/src/scripts/statusbar.js
@@ -112,9 +112,9 @@ class StatusBar extends H5P.EventDispatcher {
 
 
   updateStatusBar() {
-    const currChapter = (this.parent.activeChapter+1) ;
+    const currChapter = this.parent.getActiveChapter()+1;
     
-    const chapterTitle =  this.parent.instances[this.parent.activeChapter].title;
+    const chapterTitle =  this.parent.instances[this.parent.getActiveChapter()].title;
 
     this.headerStatus.current.innerHTML = currChapter;
     this.footerStatus.current.innerHTML = currChapter;


### PR DESCRIPTION
To avoid potential misalingments when redirecting, each section and chapter has their UUID. 

This is to avoid misalignemnts when a chapter/section is made and later moved to another position, which would not work with the old setup where redirects were calculated with a relative position